### PR TITLE
Change from six.u to the old u'' standby

### DIFF
--- a/googlegeocoder/__init__.py
+++ b/googlegeocoder/__init__.py
@@ -165,7 +165,7 @@ class Geometry(BaseAPIObject):
         return '<%s>' % (self.__class__.__name__)
 
     def __unicode__(self):
-        return six.u("Geometry")
+        return u"Geometry"
 
 
 class Bounds(BaseAPIObject):
@@ -179,7 +179,7 @@ class Bounds(BaseAPIObject):
         self.northeast = Coordinates(self.northeast)
 
     def __unicode__(self):
-        return six.u("(%s, %s)" % (self.southwest, self.northeast))
+        return u"(%s, %s)" % (self.southwest, self.northeast)
 
 
 class Coordinates(BaseAPIObject):
@@ -187,7 +187,7 @@ class Coordinates(BaseAPIObject):
     A lat/lng pair.
     """
     def __unicode__(self):
-        return six.u("(%s, %s)" % (self.lat, self.lng))
+        return u"(%s, %s)" % (self.lat, self.lng)
 
     @property
     def wkt(self):


### PR DESCRIPTION
From what I can tell, running six.u to create unicode strings breaks the shit out of Python 2.7. But using Python2's native u'' form seems to work just fine `¯\_(ツ)_/¯`

```
  File "/home/kschwen/dev/analysis/construction-permits/repo/permits/models.py", line 79, in geocode_intersection
    print address, search[0]
  File "/home/kschwen/dev/analysis/construction-permits/local/lib/python2.7/site-packages/googlegeocoder/__init__.py", line 66, in __str__
    return self.__unicode__().encode('utf8')
  File "/home/kschwen/dev/analysis/construction-permits/local/lib/python2.7/site-packages/googlegeocoder/__init__.py", line 110, in __unicode__
    return six.u(self.formatted_address)
  File "/home/kschwen/dev/analysis/construction-permits/local/lib/python2.7/site-packages/six.py", line 468, in u
    return unicode(s, "unicode_escape")
TypeError: decoding Unicode is not supported
```
